### PR TITLE
Fix inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DB::table('table')
 
 // You can use:
 DB::table('table')
-    ->select(new Alias(new Coalesce(['user', 'admin']), 'count'));
+    ->select(new Alias(new Coalesce(['user', 'admin']), 'value'));
 ```
 
 ## Installation


### PR DESCRIPTION
It seems that the doc example got changed somewhere along the way and alias in the Expression constructor is different than those in the SQL above.