### PR TITLE
feat: string concatenation

### DIFF
--- a/src/Function/String/Concat.php
+++ b/src/Function/String/Concat.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\QueryExpressions\Function\String;
+
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Grammar;
+use Tpetry\QueryExpressions\Concerns\IdentifiesDriver;
+use Tpetry\QueryExpressions\Function\Conditional\ManyArgumentsExpression;
+
+class Concat extends ManyArgumentsExpression implements Expression
+{
+    use IdentifiesDriver;
+
+    public function getValue(Grammar $grammar)
+    {
+        $expressions = $this->getExpressions($grammar);
+        $expressionsStr = implode(', ', $expressions);
+
+        return match ($this->identify($grammar)) {
+            'mysql', 'pgsql', 'sqlsrv' => "concat({$expressionsStr})",
+            'sqlite' => implode(' || ', $expressions),
+        };
+    }
+}

--- a/tests/Function/String/ConcatTest.php
+++ b/tests/Function/String/ConcatTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Tpetry\QueryExpressions\Function\String\Concat;
+
+it('can concatenate string values')
+    ->expect(new Concat(['Hello', ' ', 'World']))
+    ->toBeExecutable()
+    ->toBeMysql('concat(`Hello`, ` `, `World`)')
+    ->toBePgsql('concat("Hello", " ", "World")')
+    ->toBeSqlite('"Hello" || " " || "World"')
+    ->toBeSqlsrv('concat([Hello], [ ], [World])');


### PR DESCRIPTION
Hello @tpetry,

Here is my attempt to add support for string concatenation. It uses **concat** in all cases except in SQLite, where it uses the corresponding **||** operator.

I added a test but, honestly, I haven't been able to run the tests so this **needs testing** before merging.