### PR TITLE
Expression to get other value if main value is empty string

### DIFF
--- a/src/Function/Conditional/IfEmpty.php
+++ b/src/Function/Conditional/IfEmpty.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\QueryExpressions\Function\Conditional;
+
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Query\Expression;
+use Tpetry\QueryExpressions\Concerns\StringizeExpression;
+
+class IfEmpty extends Expression
+{
+    use StringizeExpression;
+
+    public function __construct(
+        private readonly string|Expression $expression,
+        private readonly string|Expression $fallbackExpression,
+    ) {
+    }
+
+    public function getValue(Grammar $grammar): string
+    {
+        return "ifnull(nullif({$this->stringize($grammar, $this->expression)},''),{$this->stringize($grammar, $this->fallbackExpression)})";
+    }
+}

--- a/tests/Function/Conditional/IfEmptyTest.php
+++ b/tests/Function/Conditional/IfEmptyTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Query\Expression;
+use Tpetry\QueryExpressions\Function\Conditional\IfEmpty;
+
+it('can use other column if main column is empty')
+    ->expect(new IfEmpty('val1', 'val2'))
+    ->toBeExecutable(['val1 varchar(255)', 'val2 varchar(255)'])
+    ->toBeMysql('ifnull(nullif(`val1`,\'\'),`val2`)')
+    ->toBePgsql('ifnull(nullif("val1",\'\'),"val2")')
+    ->toBeSqlite('ifnull(nullif("val1",\'\'),"val2")')
+    ->toBeSqlsrv('ifnull(nullif([val1],\'\'),[val2])');
+
+    it('can use expression if column is empty')
+    ->expect(new IfEmpty(new Expression('\'foo\''), new Expression('\'bar\'')))
+    ->toBeExecutable()
+    ->toBeMysql('ifnull(nullif(\'foo\',\'\'),\'bar\')')
+    ->toBePgsql('ifnull(nullif(\'foo\',\'\'),\'bar\')')
+    ->toBeSqlite('ifnull(nullif(\'foo\',\'\'),\'bar\')')
+    ->toBeSqlsrv('ifnull(nullif(\'foo\',\'\'),\'bar\')');
+
+it('can use expression if column is empty')
+    ->expect(new IfEmpty('val', new Expression('\'foo\'')))
+    ->toBeExecutable(['val varchar(255)'])
+    ->toBeMysql('ifnull(nullif(`val`,\'\'),\'foo\')')
+    ->toBePgsql('ifnull(nullif("val",\'\'),\'foo\')')
+    ->toBeSqlite('ifnull(nullif("val",\'\'),\'foo\')')
+    ->toBeSqlsrv('ifnull(nullif([val],\'\'),\'foo\')');

--- a/tests/Function/Conditional/IfEmptyTest.php
+++ b/tests/Function/Conditional/IfEmptyTest.php
@@ -13,7 +13,7 @@ it('can use other column if main column is empty')
     ->toBeSqlite('ifnull(nullif("val1",\'\'),"val2")')
     ->toBeSqlsrv('ifnull(nullif([val1],\'\'),[val2])');
 
-    it('can use expression if column is empty')
+it('can use other expression if main expression is empty')
     ->expect(new IfEmpty(new Expression('\'foo\''), new Expression('\'bar\'')))
     ->toBeExecutable()
     ->toBeMysql('ifnull(nullif(\'foo\',\'\'),\'bar\')')


### PR DESCRIPTION
The `Coalesce` expression allows you to get the first non-null value. But what if you want the first non-empty value? This PR adds an expression for that. I named it `ifempty` to make it similar to the `ifnull` database function (I don't know if adding an ifnull-expression is interesting, as an alternative for `coalesce`?)
```php
new IfEmpty('name', 'email')
```