### PR TITLE
add `DateFormat` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,39 @@ Schema::table('users', function (Blueprint $table): void {
 });
 ```
 
+#### Date Format
+
+Use [PHP's date format](https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters) syntax to format a date column.
+
+> **Warning**
+> The following format characters are not supported: `N S L X B I O P T Z z x u v e p c r`
+
+> **Note**
+  When using Sqlite, characters that produces a textual result (for example: `D` -> `Sun`,`F` -> `January`, `l` -> `Sunday`, `M` -> `Jan`), [Carbon](https://carbon.nesbot.com/docs/#api-localization) default localization will be used to build the SQL query.
+
+```php
+use Tpetry\QueryExpressions\Function\Date\DateFormat;
+use Tpetry\QueryExpressions\Language\Alias;
+
+// MySQL:
+//  SELECT url, DATE_FORMAT(created_at, '%Y-%m-%d') AS date, [....]
+// PostgreSQL:
+//  SELECT url, TO_CHAR(created_at, 'YYYY-MM-DD') AS date, [....]
+BlogVisit::select([
+    'url',
+    new Alias(new DateFormat('created_at', 'Y-m-d'), 'date'),
+    new Count('*'),
+])->groupBy(
+    'url',
+    new DateFormat('created_at', 'Y-m-d')
+)->get();
+// | url       | date       | count |
+// |-----------|------------|-------|
+// | /example1 | 2023-05-16 | 2     |
+// | /example1 | 2023-05-17 | 1     |
+// | /example1 | 2023-05-18 | 1     |
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": "^8.1",
         "illuminate/contracts": "^10.13.1",
         "illuminate/database": "^10.13.1",
-        "illuminate/support": "^10.0"
+        "illuminate/support": "^10.0",
+        "nesbot/carbon": "^2.72"
     },
     "require-dev": {
         "larastan/larastan": "^2.7.0",

--- a/src/Function/Date/DateFormat.php
+++ b/src/Function/Date/DateFormat.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\QueryExpressions\Function\Date;
+
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Grammar;
+use Tpetry\QueryExpressions\Concerns\IdentifiesDriver;
+use Tpetry\QueryExpressions\Concerns\StringizeExpression;
+use Tpetry\QueryExpressions\Function\String\Concat;
+use Tpetry\QueryExpressions\Value\Value;
+
+class DateFormat implements Expression
+{
+    use DirectDateFormat;
+    use EmulatedDateFormat;
+    use IdentifiesDriver;
+    use StringizeExpression;
+
+    /**
+     * @var array<string>
+     */
+    protected array $unsupportedCharacters = [
+        'B',
+        'c',
+        'e',
+        'I',
+        'L',
+        'N',
+        'O',
+        'P',
+        'p',
+        'r',
+        'S',
+        'T',
+        'u',
+        'v',
+        'X',
+        'x',
+        'z',
+        'Z',
+    ];
+
+    public function __construct(
+        private readonly string|Expression $expression,
+        private readonly string $format
+    ) {
+    }
+
+    public function getValue(Grammar $grammar): string
+    {
+        /** @var non-empty-array<int, Expression> $expressions */
+        $expressions = [];
+
+        $characters = $this->getFormatCharacters();
+
+        foreach ($characters as $character) {
+            $emulatedCharacter = $this->getEmulatableCharacter($grammar, $character);
+            $formatCharacter = $this->formatCharacters[$this->identify($grammar)][$character] ?? null;
+
+            if ($emulatedCharacter) {
+                $expressions[] = $this->getEmulatedExpression($grammar, $emulatedCharacter);
+            } elseif ($formatCharacter) {
+                $expressions[] = $this->getDateFormatExpression($grammar, $character);
+            } else {
+                $expressions[] = $this->getCharacterExpression($character);
+            }
+        }
+
+        return count($expressions) == 1 ?
+            (string) $expressions[0]->getValue($grammar) : (new Concat($expressions))->getValue($grammar);
+    }
+
+    protected function getCharacterExpression(string $character): Expression
+    {
+        $isEscaped = str_starts_with($character, '\\') && strlen($character) > 1;
+
+        return new Value(
+            $isEscaped ? substr($character, 1) : $character,
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getFormatCharacters(): array
+    {
+        $characters = str_split($this->format);
+
+        $characters = array_reduce(
+            array_keys($characters),
+            function (array $characters, int $index) {
+                if ($characters[$index] == '\\') {
+                    $characters[$index + 1] = $characters[$index].($characters[$index + 1] ?? null);
+                    unset($characters[$index]);
+                }
+
+                return $characters;
+            },
+            $characters
+        );
+
+        array_walk(
+            $characters,
+            function (string $character) {
+                if (in_array($character, $this->unsupportedCharacters)) {
+                    throw new \InvalidArgumentException(sprintf(
+                        'Unsupported format character: %s',
+                        $character,
+                    ));
+                }
+            }
+        );
+
+        return $characters;
+    }
+}

--- a/src/Function/Date/DirectDateFormat.php
+++ b/src/Function/Date/DirectDateFormat.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\QueryExpressions\Function\Date;
+
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Query\Expression as QueryExpression;
+
+/**
+ * @property-read string|\Illuminate\Database\Query\Expression $expression
+ *
+ * @uses \Tpetry\QueryExpressions\Concerns\IdentifiesDriver
+ * @uses \Tpetry\QueryExpressions\Concerns\StringizeExpression
+ */
+trait DirectDateFormat
+{
+    /**
+     * @var array<'mysql'|'sqlite'|'pgsql'|'sqlsrv', array<string, string>>
+     */
+    protected array $formatCharacters = [
+        'mysql' => [
+            'A' => '%p',
+            'd' => '%d',
+            'D' => '%a',
+            'F' => '%M',
+            'H' => '%H',
+            'h' => '%h',
+            'i' => '%i',
+            'j' => '%e',
+            'l' => '%W',
+            'm' => '%m',
+            'M' => '%b',
+            'n' => '%c',
+            'o' => '%x',
+            's' => '%s',
+            'W' => '%v',
+            'Y' => '%Y',
+            'y' => '%y',
+        ],
+        'sqlite' => [
+            'A' => '%p',
+            'd' => '%d',
+            'H' => '%H',
+            'i' => '%M',
+            'm' => '%m',
+            's' => '%S',
+            'U' => '%s',
+            'Y' => '%Y',
+        ],
+        'pgsql' => [
+            'A' => 'AM',
+            'd' => 'DD',
+            'D' => 'Dy',
+            'h' => 'HH12',
+            'H' => 'HH24',
+            'i' => 'MI',
+            'j' => 'FMDD',
+            'm' => 'MM',
+            'M' => 'Mon',
+            'n' => 'FMMM',
+            's' => 'SS',
+            'W' => 'IW',
+            'y' => 'YY',
+            'Y' => 'YYYY',
+        ],
+        'sqlsrv' => [
+            'A' => 'tt',
+            'd' => 'dd',
+            'D' => 'ddd',
+            'h' => 'hh',
+            'H' => 'HH',
+            'i' => 'mm',
+            'm' => 'MM',
+            's' => 'ss',
+            'Y' => 'yyyy',
+        ],
+    ];
+
+    protected function getDateFormatExpression(Grammar $grammar, string $character): Expression
+    {
+        $formatCharacter = $this->formatCharacters[$this->identify($grammar)][$character];
+
+        return new QueryExpression(
+            match ($this->identify($grammar)) {
+                'mysql' => "DATE_FORMAT({$this->stringize($grammar, $this->expression)}, '{$formatCharacter}')",
+                'sqlite' => "STRFTIME('{$formatCharacter}', {$this->stringize($grammar, $this->expression)})",
+                'pgsql' => "TO_CHAR({$this->stringize($grammar, $this->expression)}, '{$formatCharacter}')",
+                'sqlsrv' => "FORMAT({$this->stringize($grammar, $this->expression)}, '{$formatCharacter}')",
+            }
+        );
+    }
+}

--- a/src/Function/Date/EmulatedDateFormat.php
+++ b/src/Function/Date/EmulatedDateFormat.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\QueryExpressions\Function\Date;
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Query\Expression as QueryExpression;
+
+/**
+ * @property-read string|\Illuminate\Database\Query\Expression $expression
+ *
+ * @uses \Tpetry\QueryExpressions\Concerns\IdentifiesDriver
+ * @uses \Tpetry\QueryExpressions\Concerns\StringizeExpression
+ */
+trait EmulatedDateFormat
+{
+    protected function getEmulatedExpression(Grammar $grammar, string|Expression $emulatedCharacter): Expression
+    {
+        if ($grammar->isExpression($emulatedCharacter)) {
+            $emulatedCharacter = $this->stringize($grammar, $emulatedCharacter);
+        }
+
+        /** @var string $emulatedCharacter */
+        return new QueryExpression(sprintf(
+            $emulatedCharacter,
+            ...array_fill(
+                start_index: 0,
+                count: substr_count($emulatedCharacter, '%s'),
+                value: $this->stringize($grammar, $this->expression)
+            )
+        ));
+    }
+
+    protected function getEmulatableCharacter(Grammar $grammar, string $character): string|Expression|null
+    {
+        return match ($this->identify($grammar)) {
+            'mysql' => $this->getEmulatableCharacterForMysql($character),
+            'sqlite' => $this->getEmulatableCharacterForSqlite($character),
+            'pgsql' => $this->getEmulatableCharacterForPgsql($character),
+            'sqlsrv' => $this->getEmulatableCharacterForSqlsrv($character),
+        };
+    }
+
+    protected function getEmulatableCharacterForMysql(string $character): string|Expression|null
+    {
+        return match ($character) {
+            'a' => 'LOWER(DATE_FORMAT(%s, \'%%p\'))',
+            'g' => '(HOUR(%s) + 11) %% 12 + 1',
+            'G' => 'HOUR(%s)',
+            't' => 'DAY(LAST_DAY(%s))',
+            'U' => 'UNIX_TIMESTAMP(%s)',
+            'w' => '(DAYOFWEEK(%s) + 5) %% 7 + 1',
+            default => null,
+        };
+    }
+
+    protected function getEmulatableCharacterForSqlite(string $character): string|Expression|null
+    {
+        /** @var array<int, int> $daysRange */
+        $daysRange = range(0, 6);
+        /** @var array<int, int> $monthsRange */
+        $monthsRange = range(1, 12);
+
+        /** @var array<string, string> $dayAbbreviations */
+        $dayAbbreviations = array_map(
+            // @phpstan-ignore-next-line
+            fn ($dayIndex) => Carbon::now()->weekday($dayIndex)->getTranslatedShortDayName(),
+            $daysRange
+        );
+
+        /** @var array<string, string> $monthFullNames */
+        $monthFullNames = array_map(
+            fn ($monthIndex) => Carbon::now()->month($monthIndex)->getTranslatedMonthName(),
+            $monthsRange
+        );
+
+        /** @var array<string, string> $dayFullNames */
+        $dayFullNames = array_map(
+            // @phpstan-ignore-next-line
+            fn ($dayIndex) => Carbon::now()->weekday($dayIndex)->getTranslatedDayName(),
+            $daysRange
+        );
+
+        /** @var array<string, string> $monthShortNames */
+        $monthShortNames = array_map(
+            fn ($monthIndex) => Carbon::now()->month($monthIndex)->getTranslatedShortMonthName(),
+            $monthsRange
+        );
+
+        return match ($character) {
+            'a' => 'LOWER(STRFTIME(\'%%p\', %s))',
+            'D' => sprintf(
+                '(CASE %s END)',
+                implode(
+                    ' ',
+                    array_map(
+                        fn ($dayIndex, $dayAbbrev) => "WHEN CAST(STRFTIME('%%w', %s) AS INTEGER) = $dayIndex THEN '$dayAbbrev'",
+                        $daysRange,
+                        $dayAbbreviations
+                    )
+                )
+            ),
+            'F' => sprintf(
+                '(CASE %s END)',
+                implode(
+                    ' ',
+                    array_map(
+                        fn ($monthIndex, $monthFull) => "WHEN CAST(STRFTIME('%%m', %s) AS INTEGER) = $monthIndex THEN '$monthFull'",
+                        $monthsRange,
+                        $monthFullNames
+                    )
+                )
+            ),
+
+            'g' => '(STRFTIME(\'%%H\', %s) + 11) %% 12 + 1',
+            'G' => 'LTRIM(STRFTIME(\'%%H\', %s), \'0\')',
+            'h' => '(CASE WHEN STRFTIME(\'%%H\', %s) > \'12\' THEN STRFTIME(\'%%H\', %s) - 12 ELSE STRFTIME(\'%%H\', %s) END)',
+            'j' => 'LTRIM(STRFTIME(\'%%d\', %s), \'0\')',
+            'l' => sprintf(
+                '(CASE %s END)',
+                implode(
+                    ' ',
+                    array_map(
+                        fn ($dayIndex, $dayFull) => "WHEN CAST(STRFTIME('%%w', %s) AS INTEGER) = $dayIndex THEN '$dayFull'",
+                        $daysRange,
+                        $dayFullNames
+                    )
+                )
+            ),
+            'M' => sprintf(
+                '(CASE %s END)',
+                implode(
+                    ' ',
+                    array_map(
+                        fn ($monthIndex, $monthShort) => "WHEN CAST(STRFTIME('%%m', %s) AS INTEGER) = $monthIndex THEN '$monthShort'",
+                        $monthsRange,
+                        $monthShortNames
+                    )
+                )
+            ),
+            'n' => 'LTRIM(STRFTIME(\'%%m\', %s), \'0\')',
+            'o' => 'STRFTIME(\'%%Y\', %s, \'weekday 0\', \'-3 days\')',
+            't' => 'STRFTIME(\'%%d\', DATE(%s, \'+1 month\', \'start of month\', \'-1 day\'))',
+            'W' => '(STRFTIME(\'%%j\', %s, \'weekday 0\', \'-3 days\') - 1) / 7 + 1',
+            'w' => '(STRFTIME(\'%%w\', %s) + 6) %% 7 + 1',
+            'y' => 'SUBSTR(STRFTIME(\'%%Y\', %s), 3, 2)',
+            default => null,
+        };
+    }
+
+    protected function getEmulatableCharacterForPgsql(string $character): string|Expression|null
+    {
+        return match ($character) {
+            'a' => 'LOWER(TO_CHAR(%s, \'AM\'))',
+            'F' => 'TRIM(TO_CHAR(%s, \'Month\'))',
+            'g' => '(CAST((EXTRACT(HOUR FROM %s)::INTEGER + 11) %% 12 + 1 AS VARCHAR(2)))',
+            'G' => 'CAST(EXTRACT(HOUR FROM %s)::INTEGER AS VARCHAR(2))',
+            'l' => 'TRIM(TO_CHAR(%s, \'Day\'))',
+            'o' => '(CASE WHEN EXTRACT(MONTH FROM %s)::INTEGER = 1 AND EXTRACT(DAY FROM %s)::INTEGER <= 3 THEN EXTRACT(YEAR FROM %s)::INTEGER - 1 ELSE EXTRACT(YEAR FROM %s)::INTEGER END)',
+            't' => 'EXTRACT(DAY FROM DATE_TRUNC(\'month\', %s) + INTERVAL \'1 month - 1 day\')::INTEGER',
+            'U' => 'EXTRACT(EPOCH FROM %s)::INTEGER',
+            'w' => 'EXTRACT(DOW FROM %s)::INTEGER',
+            default => null,
+        };
+    }
+
+    protected function getEmulatableCharacterForSqlsrv(string $character): string|Expression|null
+    {
+        return match ($character) {
+            'a' => 'LOWER(FORMAT(%s, \'tt\'))',
+            'F' => 'DATENAME(MONTH, %s)',
+            'g' => '(DATEPART(HOUR, %s) + 11) %% 12 + 1',
+            'G' => 'CAST(DATEPART(HOUR, %s) AS VARCHAR(2))',
+            'j' => 'CAST(DAY(%s) AS VARCHAR(2))',
+            'l' => 'DATENAME(WEEKDAY, %s)',
+            'M' => 'LEFT(DATENAME(MONTH, %s), 3)',
+            'n' => 'CAST(MONTH(%s) AS VARCHAR(2))',
+            'o' => '(CASE WHEN MONTH(%s) = 1 AND DAY(%s) <= 3 THEN YEAR(%s) - 1 ELSE YEAR(%s) END)',
+            't' => 'CAST(DAY(EOMONTH(%s)) AS VARCHAR(2))',
+            'U' => 'DATEDIFF(SECOND, \'1970-01-01\', %s)',
+            'w' => '(CAST(DATEPART(WEEKDAY, %s) AS VARCHAR(2)) + 5) %% 7 + 1',
+            'W' => 'CAST(DATEPART(ISO_WEEK, %s) AS VARCHAR(2))',
+            'y' => 'RIGHT(CAST(YEAR(%s) AS VARCHAR(4)), 2)',
+            default => null,
+        };
+    }
+}

--- a/tests/Function/Date/DateFormatTest.php
+++ b/tests/Function/Date/DateFormatTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tpetry\QueryExpressions\Function\Date\DateFormat;
+
+it('can format dates: [Y-m-d H:i:s]')
+    ->expect(new DateFormat('created_at', format: 'Y-m-d H:i:s'))
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->dateTime('created_at');
+    })
+    ->toBePgsql('(TO_CHAR("created_at", \'YYYY\')||\'-\'||TO_CHAR("created_at", \'MM\')||\'-\'||TO_CHAR("created_at", \'DD\')||\' \'||TO_CHAR("created_at", \'HH24\')||\':\'||TO_CHAR("created_at", \'MI\')||\':\'||TO_CHAR("created_at", \'SS\'))')
+    ->toBeSqlite('(STRFTIME(\'%Y\', "created_at")||\'-\'||STRFTIME(\'%m\', "created_at")||\'-\'||STRFTIME(\'%d\', "created_at")||\' \'||STRFTIME(\'%H\', "created_at")||\':\'||STRFTIME(\'%M\', "created_at")||\':\'||STRFTIME(\'%S\', "created_at"))')
+    ->toBeMysql('(concat(DATE_FORMAT(`created_at`, \'%Y\'),\'-\',DATE_FORMAT(`created_at`, \'%m\'),\'-\',DATE_FORMAT(`created_at`, \'%d\'),\' \',DATE_FORMAT(`created_at`, \'%H\'),\':\',DATE_FORMAT(`created_at`, \'%i\'),\':\',DATE_FORMAT(`created_at`, \'%s\')))')
+    ->toBeSqlsrv('(concat(FORMAT([created_at], \'yyyy\'),\'-\',FORMAT([created_at], \'MM\'),\'-\',FORMAT([created_at], \'dd\'),\' \',FORMAT([created_at], \'HH\'),\':\',FORMAT([created_at], \'mm\'),\':\',FORMAT([created_at], \'ss\')))');
+
+it('can format dates: [Y] format character, no concat')
+    ->expect(new DateFormat('created_at', format: 'Y'))
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->dateTime('created_at');
+    })
+    ->toBePgsql('TO_CHAR("created_at", \'YYYY\')')
+    ->toBeSqlite('STRFTIME(\'%Y\', "created_at")')
+    ->toBeMysql('DATE_FORMAT(`created_at`, \'%Y\')')
+    ->toBeSqlsrv('FORMAT([created_at], \'yyyy\')');
+
+it('can format dates: [U] emulated character, no concat')
+    ->expect(new DateFormat('created_at', format: 'U'))
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->dateTime('created_at');
+    })
+    ->toBePgsql('EXTRACT(EPOCH FROM "created_at")::INTEGER')
+    ->toBeSqlite('STRFTIME(\'%s\', "created_at")')
+    ->toBeMysql('UNIX_TIMESTAMP(`created_at`)')
+    ->toBeSqlsrv('DATEDIFF(SECOND, \'1970-01-01\', [created_at])');
+
+it('can format dates', function () {
+
+    if (
+        DB::connection()->getDriverName() === 'mysql'
+    ) {
+        DB::statement('SET time_zone = \'+00:00\'');
+    }
+
+    $testData = [
+        '2021-01-01 12:00:00' => [
+            'g' => '12',
+        ],
+        '2021-01-01 00:00:00' => [
+            'g' => '12',
+            '\yy\\' => 'y21\\',
+        ],
+        '2021-01-01 09:00:00' => [
+            'a' => 'am',
+            'A' => 'AM',
+            'd' => '01',
+            'D' => 'Fri',
+            'F' => 'January',
+            'G' => '9',
+            'g' => '9',
+            'H' => '09',
+            'h' => '09',
+            'i' => '00',
+            'j' => '1',
+            'l' => 'Friday',
+            'm' => '01',
+            'M' => 'Jan',
+            'n' => '1',
+            'o' => '2020',
+            's' => '00',
+            't' => '31',
+            'U' => '1609491600',
+            'w' => '5',
+            'W' => '53',
+            'Y' => '2021',
+            'y' => '21',
+        ],
+        '2021-12-09 19:02:37' => [
+            'a' => 'pm',
+            'A' => 'PM',
+            'd' => '09',
+            'D' => 'Thu',
+            'F' => 'December',
+            'G' => '19',
+            'g' => '7',
+            'h' => '07',
+            'H' => '19',
+            'i' => '02',
+            'j' => '9',
+            'l' => 'Thursday',
+            'm' => '12',
+            'M' => 'Dec',
+            'n' => '12',
+            'o' => '2021',
+            's' => '37',
+            't' => '31',
+            'U' => '1639076557',
+            'w' => '4',
+            'W' => '49',
+            'Y' => '2021',
+            'y' => '21',
+        ],
+    ];
+
+    foreach ($testData as $date => $expected) {
+        Schema::create($table = 'example_'.mt_rand(), function (Blueprint $table) {
+            $table->dateTime('created_at');
+        });
+
+        DB::table($table)->insert([
+            'created_at' => $date,
+        ]);
+
+        foreach ($expected as $format => $expected) {
+            expect(
+                DB::table($table)->selectRaw(
+                    new DateFormat('created_at', $format)
+                )->value('created_at')
+            )->toEqual($expected, "format: {$format}");
+        }
+    }
+});
+
+it('throws exception for unsupported characters', function () {
+    Schema::create($table = 'example_'.mt_rand(), function (Blueprint $table) {
+        $table->dateTime('created_at');
+    });
+
+    DB::table($table)->insert([
+        'created_at' => '2021-01-01 09:00:00',
+    ]);
+
+    DB::table($table)->selectRaw(
+        new DateFormat('created_at', 'N')
+    )->value('created_at');
+
+})->throws(InvalidArgumentException::class, 'Unsupported format character: N');
+
+it('doesn\'t throw exception for escaped characters', function () {
+    Schema::create($table = 'example_'.mt_rand(), function (Blueprint $table) {
+        $table->dateTime('created_at');
+    });
+
+    DB::table($table)->insert([
+        'created_at' => '2021-01-01 09:00:00',
+    ]);
+
+    expect(
+        DB::table($table)->selectRaw(
+            new DateFormat('created_at', '\N')
+        )->value('created_at')
+    )->toEqual('N');
+});


### PR DESCRIPTION
Following up on #15 and the discussion by @phillipfickl https://github.com/tpetry/laravel-query-expressions/discussions/7#discussioncomment-6176585 

Used resources:
- Drupal's MySQL class:
https://github.com/drupal/drupal/blob/eafbd246a944b20d1f507cae159fd9574440512e/core/modules/views/src/Plugin/views/query/MysqlDateSql.php#L27-L45
- Drupal's Postgres class:
https://github.com/drupal/drupal/blob/eafbd246a944b20d1f507cae159fd9574440512e/core/modules/views/src/Plugin/views/query/PostgresqlDateSql.php#L32-L51
- Drupal's sqlite class: https://github.com/drupal/drupal/blob/eafbd246a944b20d1f507cae159fd9574440512e/core/modules/views/src/Plugin/views/query/SqliteDateSql.php#L32-L58
- [date (Transact-SQL) - SQL Server | Microsoft Learn](https://learn.microsoft.com/en-us/sql/t-sql/data-types/date-transact-sql?view=sql-server-ver16)
- [CAST and CONVERT (Transact-SQL) - SQL Server](https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver16)
