### PR TITLE
chore: tests: use schema builder for columns setup

### DIFF
--- a/tests/Function/Aggregate/AvgTest.php
+++ b/tests/Function/Aggregate/AvgTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Aggregate\Avg;
 
 it('can aggregate a column by AVG')
     ->expect(new Avg('val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('avg(`val`)')
     ->toBePgsql('avg("val")')
     ->toBeSqlite('avg("val")')

--- a/tests/Function/Aggregate/CountFilterTest.php
+++ b/tests/Function/Aggregate/CountFilterTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Aggregate\CountFilter;
 
 it('can aggregate a column by COUNT with a filter')
     ->expect(new CountFilter(new Expression('val = 1')))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('sum(val = 1)')
     ->toBePgsql('count(*) filter (where val = 1)')
     ->toBeSqlite('count(*) filter (where val = 1)')

--- a/tests/Function/Aggregate/CountTest.php
+++ b/tests/Function/Aggregate/CountTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Aggregate\Count;
 
 it('can aggregate a column by COUNT')
     ->expect(new Count('val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('count(`val`)')
     ->toBePgsql('count("val")')
     ->toBeSqlite('count("val")')
@@ -15,7 +18,9 @@ it('can aggregate a column by COUNT')
 
 it('can aggregate a column by COUNT with DISTINCT')
     ->expect(new Count('val', true))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('count(distinct `val`)')
     ->toBePgsql('count(distinct "val")')
     ->toBeSqlite('count(distinct "val")')

--- a/tests/Function/Aggregate/MaxTest.php
+++ b/tests/Function/Aggregate/MaxTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Aggregate\Max;
 
 it('can aggregate a column by MAX')
     ->expect(new Max('val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('max(`val`)')
     ->toBePgsql('max("val")')
     ->toBeSqlite('max("val")')

--- a/tests/Function/Aggregate/MinTest.php
+++ b/tests/Function/Aggregate/MinTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Aggregate\Min;
 
 it('can aggregate a column by MIN')
     ->expect(new Min('val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('min(`val`)')
     ->toBePgsql('min("val")')
     ->toBeSqlite('min("val")')

--- a/tests/Function/Aggregate/SumFilterTest.php
+++ b/tests/Function/Aggregate/SumFilterTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Aggregate\SumFilter;
 
 it('can aggregate a column by SUM with a filter')
     ->expect(new SumFilter('val1', new Expression('val2 = 1')))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('sum(case when val2 = 1 then `val1` else 0 end)')
     ->toBePgsql('sum("val1") filter (where val2 = 1)')
     ->toBeSqlite('sum("val1") filter (where val2 = 1)')
@@ -15,7 +19,9 @@ it('can aggregate a column by SUM with a filter')
 
 it('can aggregate an expression by SUM with a filter')
     ->expect(new SumFilter(new Expression(1), new Expression('val = 1')))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('sum(case when val = 1 then 1 else 0 end)')
     ->toBePgsql('sum(1) filter (where val = 1)')
     ->toBeSqlite('sum(1) filter (where val = 1)')

--- a/tests/Function/Aggregate/SumTest.php
+++ b/tests/Function/Aggregate/SumTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Aggregate\Sum;
 
 it('can aggregate a column by SUM')
     ->expect(new Sum('val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('sum(`val`)')
     ->toBePgsql('sum("val")')
     ->toBeSqlite('sum("val")')

--- a/tests/Function/Comparison/StrListContainsTest.php
+++ b/tests/Function/Comparison/StrListContainsTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Comparison\StrListContains;
 
 it('can check for existence of a column within a column string list')
     ->expect(new StrListContains('haystack', 'needle'))
-    ->toBeExecutable(['haystack varchar(255)', 'needle varchar(255)'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('haystack');
+        $table->string('needle');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('FIND_IN_SET(`needle`, `haystack`) > 0')
@@ -27,7 +31,9 @@ it('can check for existence of an expression within an expression string list')
 
 it('can check for existence of a column within an expression string list')
     ->expect(new StrListContains(new Expression("'a,b,c'"), 'needle'))
-    ->toBeExecutable(['needle varchar(255)'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('needle');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql("FIND_IN_SET(`needle`, 'a,b,c') > 0")
@@ -37,7 +43,9 @@ it('can check for existence of a column within an expression string list')
 
 it('can check for existence of an expression within a column string list')
     ->expect(new StrListContains('haystack', new Expression("'a'")))
-    ->toBeExecutable(['haystack varchar(255)'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('haystack');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql("FIND_IN_SET('a', `haystack`) > 0")

--- a/tests/Function/Conditional/CoalesceTest.php
+++ b/tests/Function/Conditional/CoalesceTest.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Conditional\Coalesce;
 
 it('can combine multiple columns')
     ->expect(new Coalesce(['val1', 'val2', 'val3']))
-    ->toBeExecutable(['val1 int', 'val2 int', 'val3 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+        $table->integer('val3');
+    })
     ->toBeMysql('coalesce(`val1`, `val2`, `val3`)')
     ->toBePgsql('coalesce("val1", "val2", "val3")')
     ->toBeSqlite('coalesce("val1", "val2", "val3")')
@@ -23,7 +28,10 @@ it('can combine multiple expressions')
 
 it('can combine multiple columns and expressions')
     ->expect(new Coalesce(['val1', 'val2', new Expression(3)]))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('coalesce(`val1`, `val2`, 3)')
     ->toBePgsql('coalesce("val1", "val2", 3)')
     ->toBeSqlite('coalesce("val1", "val2", 3)')

--- a/tests/Function/Conditional/GreatestTest.php
+++ b/tests/Function/Conditional/GreatestTest.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Conditional\Greatest;
 
 it('can combine multiple columns')
     ->expect(new Greatest(['val1', 'val2', 'val3']))
-    ->toBeExecutable(['val1 int', 'val2 int', 'val3 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+        $table->integer('val3');
+    })
     ->toBeMysql('greatest(`val1`, `val2`, `val3`)')
     ->toBePgsql('greatest("val1", "val2", "val3")')
     ->toBeSqlite('max("val1", "val2", "val3")')
@@ -23,7 +28,10 @@ it('can combine multiple expressions')
 
 it('can combine multiple columns and expressions')
     ->expect(new Greatest(['val1', 'val2', new Expression(3)]))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('greatest(`val1`, `val2`, 3)')
     ->toBePgsql('greatest("val1", "val2", 3)')
     ->toBeSqlite('max("val1", "val2", 3)')

--- a/tests/Function/Conditional/LeastTest.php
+++ b/tests/Function/Conditional/LeastTest.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\Conditional\Least;
 
 it('can combine multiple columns')
     ->expect(new Least(['val1', 'val2', 'val3']))
-    ->toBeExecutable(['val1 int', 'val2 int', 'val3 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+        $table->integer('val3');
+    })
     ->toBeMysql('least(`val1`, `val2`, `val3`)')
     ->toBePgsql('least("val1", "val2", "val3")')
     ->toBeSqlite('min("val1", "val2", "val3")')
@@ -23,7 +28,10 @@ it('can combine multiple expressions')
 
 it('can combine multiple columns and expressions')
     ->expect(new Least(['val1', 'val2', new Expression(3)]))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('least(`val1`, `val2`, 3)')
     ->toBePgsql('least("val1", "val2", 3)')
     ->toBeSqlite('min("val1", "val2", 3)')

--- a/tests/Function/String/ConcatTest.php
+++ b/tests/Function/String/ConcatTest.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\String\Concat;
 
 it('can concat multiple columns')
     ->expect(new Concat(['val1', 'val2', 'val3']))
-    ->toBeExecutable(['val1 varchar(255)', 'val2 varchar(255)', 'val3 varchar(255)'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('val1');
+        $table->string('val2');
+        $table->string('val3');
+    })
     ->toBeMysql('(concat(`val1`,`val2`,`val3`))')
     ->toBePgsql('("val1"||"val2"||"val3")')
     ->toBeSqlite('("val1"||"val2"||"val3")')
@@ -23,7 +28,10 @@ it('can concat multiple expressions')
 
 it('can concat multiple columns and expressions')
     ->expect(new Concat(['val1', 'val2', new Expression("'c'")]))
-    ->toBeExecutable(['val1 varchar(255)', 'val2 varchar(255)'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('val1');
+        $table->string('val2');
+    })
     ->toBeMysql("(concat(`val1`,`val2`,'c'))")
     ->toBePgsql('("val1"||"val2"||\'c\')')
     ->toBeSqlite('("val1"||"val2"||\'c\')')

--- a/tests/Function/String/LowerTest.php
+++ b/tests/Function/String/LowerTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\String\Lower;
 
 it('can lowercase a column')
     ->expect(new Lower('val'))
-    ->toBeExecutable(['val varchar(255)'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('val');
+    })
     ->toBeMysql('(lower(`val`))')
     ->toBePgsql('lower("val")')
     ->toBeSqlite('(lower("val"))')

--- a/tests/Function/String/UpperTest.php
+++ b/tests/Function/String/UpperTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Function\String\Upper;
 
 it('can uppercase a column')
     ->expect(new Upper('val'))
-    ->toBeExecutable(['val varchar(255)'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('val');
+    })
     ->toBeMysql('(upper(`val`))')
     ->toBePgsql('upper("val")')
     ->toBeSqlite('(upper("val"))')

--- a/tests/Function/Time/TimestampBinTest.php
+++ b/tests/Function/Time/TimestampBinTest.php
@@ -3,12 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Tpetry\QueryExpressions\Function\Time\TimestampBin;
 
 it('can bin the time of a column')
     ->expect(new TimestampBin('val', DateInterval::createFromDateString('5 minutes')))
-    ->toBeExecutable(['val timestamp'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->timestamp('val');
+    })
     ->toBeMysql('(from_unixtime(floor((unix_timestamp(`val`)-0)/300)*300+0))')
     ->toBePgsql('to_timestamp(floor((extract(epoch from "val")-0)/300)*300+0)')
     ->toBeSqlite('(datetime((strftime(\'%s\',"val")-0)/300*300+0,\'unixepoch\'))')
@@ -16,7 +19,9 @@ it('can bin the time of a column')
 
 it('can bin the time of an expression')
     ->expect(new TimestampBin(new Expression('current_timestamp'), DateInterval::createFromDateString('1 minute')))
-    ->toBeExecutable(['val timestamp'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->timestamp('val');
+    })
     ->toBeMysql('(from_unixtime(floor((unix_timestamp(current_timestamp)-0)/60)*60+0))')
     ->toBePgsql('to_timestamp(floor((extract(epoch from current_timestamp)-0)/60)*60+0)')
     ->toBeSqlite('(datetime((strftime(\'%s\',current_timestamp)-0)/60*60+0,\'unixepoch\'))')
@@ -24,7 +29,9 @@ it('can bin the time of an expression')
 
 it('can bin the time of a column with an origin')
     ->expect(new TimestampBin('val', DateInterval::createFromDateString('90 seconds'), DateTime::createFromFormat('Y-m-d H:i:s', '2022-02-02 22:22:22')))
-    ->toBeExecutable(['val timestamp'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->timestamp('val');
+    })
     ->toBeMysql('(from_unixtime(floor((unix_timestamp(`val`)-1643840542)/90)*90+1643840542))')
     ->toBePgsql('to_timestamp(floor((extract(epoch from "val")-1643840542)/90)*90+1643840542)')
     ->toBeSqlite('(datetime((strftime(\'%s\',"val")-1643840542)/90*90+1643840542,\'unixepoch\'))')
@@ -32,7 +39,9 @@ it('can bin the time of a column with an origin')
 
 it('can bin the time of an expression with an origin')
     ->expect(new TimestampBin(new Expression('current_timestamp'), DateInterval::createFromDateString('1 hour'), DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-01 00:00:00')))
-    ->toBeExecutable(['val timestamp'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->timestamp('val');
+    })
     ->toBeMysql('(from_unixtime(floor((unix_timestamp(current_timestamp)-946684800)/3600)*3600+946684800))')
     ->toBePgsql('to_timestamp(floor((extract(epoch from current_timestamp)-946684800)/3600)*3600+946684800)')
     ->toBeSqlite('(datetime((strftime(\'%s\',current_timestamp)-946684800)/3600*3600+946684800,\'unixepoch\'))')

--- a/tests/Language/AliasTest.php
+++ b/tests/Language/AliasTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Language\Alias;
 
 it('can alias a column')
     ->expect(new Alias('val', 'value'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('`val` as `value`')
     ->toBePgsql('"val" as "value"')
     ->toBeSqlite('"val" as "value"')

--- a/tests/Operator/Arithmetic/AddTest.php
+++ b/tests/Operator/Arithmetic/AddTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Arithmetic\Add;
 
 it('can add two columns')
     ->expect(new Add('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` + `val2`)')
     ->toBePgsql('("val1" + "val2")')
     ->toBeSqlite('("val1" + "val2")')
@@ -23,7 +27,9 @@ it('can add two expressions')
 
 it('can add an expression and a column')
     ->expect(new Add('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` + 0)')
     ->toBePgsql('("val" + 0)')
     ->toBeSqlite('("val" + 0)')
@@ -31,7 +37,9 @@ it('can add an expression and a column')
 
 it('can add a column and an expression')
     ->expect(new Add(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 + `val`)')
     ->toBePgsql('(0 + "val")')
     ->toBeSqlite('(0 + "val")')

--- a/tests/Operator/Arithmetic/DivideTest.php
+++ b/tests/Operator/Arithmetic/DivideTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Arithmetic\Divide;
 
 it('can divide two columns')
     ->expect(new Divide('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` / `val2`)')
     ->toBePgsql('("val1" / "val2")')
     ->toBeSqlite('("val1" / "val2")')
@@ -23,7 +27,9 @@ it('can divide two expressions')
 
 it('can divide an expression and a column')
     ->expect(new Divide('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` / 0)')
     ->toBePgsql('("val" / 0)')
     ->toBeSqlite('("val" / 0)')
@@ -31,7 +37,9 @@ it('can divide an expression and a column')
 
 it('can divide a column and an expression')
     ->expect(new Divide(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 / `val`)')
     ->toBePgsql('(0 / "val")')
     ->toBeSqlite('(0 / "val")')

--- a/tests/Operator/Arithmetic/ModuloTest.php
+++ b/tests/Operator/Arithmetic/ModuloTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Arithmetic\Modulo;
 
 it('can modulo two columns')
     ->expect(new Modulo('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` % `val2`)')
     ->toBePgsql('("val1" % "val2")')
     ->toBeSqlite('("val1" % "val2")')
@@ -23,7 +27,9 @@ it('can modulo two expressions')
 
 it('can modulo an expression and a column')
     ->expect(new Modulo('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` % 0)')
     ->toBePgsql('("val" % 0)')
     ->toBeSqlite('("val" % 0)')
@@ -31,7 +37,9 @@ it('can modulo an expression and a column')
 
 it('can modulo a column and an expression')
     ->expect(new Modulo(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 % `val`)')
     ->toBePgsql('(0 % "val")')
     ->toBeSqlite('(0 % "val")')

--- a/tests/Operator/Arithmetic/MultiplyTest.php
+++ b/tests/Operator/Arithmetic/MultiplyTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Arithmetic\Multiply;
 
 it('can multiply two columns')
     ->expect(new Multiply('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` * `val2`)')
     ->toBePgsql('("val1" * "val2")')
     ->toBeSqlite('("val1" * "val2")')
@@ -23,7 +27,9 @@ it('can multiply two expressions')
 
 it('can multiply an expression and a column')
     ->expect(new Multiply('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` * 0)')
     ->toBePgsql('("val" * 0)')
     ->toBeSqlite('("val" * 0)')
@@ -31,7 +37,9 @@ it('can multiply an expression and a column')
 
 it('can multiply a column and an expression')
     ->expect(new Multiply(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 * `val`)')
     ->toBePgsql('(0 * "val")')
     ->toBeSqlite('(0 * "val")')

--- a/tests/Operator/Arithmetic/PowerTest.php
+++ b/tests/Operator/Arithmetic/PowerTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Arithmetic\Power;
 
 it('can power two columns')
     ->expect(new Power('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('power(`val1`, `val2`)')
     ->toBePgsql('("val1" ^ "val2")')
     ->toBeSqlite('power("val1", "val2")')
@@ -23,7 +27,9 @@ it('can power two expressions')
 
 it('can power an expression and a column')
     ->expect(new Power('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('power(`val`, 0)')
     ->toBePgsql('("val" ^ 0)')
     ->toBeSqlite('power("val", 0)')
@@ -31,7 +37,9 @@ it('can power an expression and a column')
 
 it('can power a column and an expression')
     ->expect(new Power(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('power(0, `val`)')
     ->toBePgsql('(0 ^ "val")')
     ->toBeSqlite('power(0, "val")')

--- a/tests/Operator/Arithmetic/SubtractTest.php
+++ b/tests/Operator/Arithmetic/SubtractTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Arithmetic\Subtract;
 
 it('can subtract two columns')
     ->expect(new Subtract('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` - `val2`)')
     ->toBePgsql('("val1" - "val2")')
     ->toBeSqlite('("val1" - "val2")')
@@ -23,7 +27,9 @@ it('can subtract two expressions')
 
 it('can subtract an expression and a column')
     ->expect(new Subtract('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` - 0)')
     ->toBePgsql('("val" - 0)')
     ->toBeSqlite('("val" - 0)')
@@ -31,7 +37,9 @@ it('can subtract an expression and a column')
 
 it('can subtract a column and an expression')
     ->expect(new Subtract(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 - `val`)')
     ->toBePgsql('(0 - "val")')
     ->toBeSqlite('(0 - "val")')

--- a/tests/Operator/Bitwise/BitAndTest.php
+++ b/tests/Operator/Bitwise/BitAndTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Bitwise\BitAnd;
 
 it('can bitwise AND two columns')
     ->expect(new BitAnd('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` & `val2`)')
     ->toBePgsql('("val1" & "val2")')
     ->toBeSqlite('("val1" & "val2")')
@@ -23,7 +27,9 @@ it('can bitwise AND two expressions')
 
 it('can bitwise AND an expression and a column')
     ->expect(new BitAnd('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` & 0)')
     ->toBePgsql('("val" & 0)')
     ->toBeSqlite('("val" & 0)')
@@ -31,7 +37,9 @@ it('can bitwise AND an expression and a column')
 
 it('can bitwise AND a column and an expression')
     ->expect(new BitAnd(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 & `val`)')
     ->toBePgsql('(0 & "val")')
     ->toBeSqlite('(0 & "val")')

--- a/tests/Operator/Bitwise/BitNotTest.php
+++ b/tests/Operator/Bitwise/BitNotTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Bitwise\BitNot;
 
 it('can bitwise NOT a column')
     ->expect(new BitNot('val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(~`val`)')
     ->toBePgsql('(~"val")')
     ->toBeSqlite('(~"val")')

--- a/tests/Operator/Bitwise/BitOrTest.php
+++ b/tests/Operator/Bitwise/BitOrTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Bitwise\BitOr;
 
 it('can bitwise OR two columns')
     ->expect(new BitOr('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` | `val2`)')
     ->toBePgsql('("val1" | "val2")')
     ->toBeSqlite('("val1" | "val2")')
@@ -23,7 +27,9 @@ it('can bitwise OR two expressions')
 
 it('can bitwise OR an expression and a column')
     ->expect(new BitOr('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` | 0)')
     ->toBePgsql('("val" | 0)')
     ->toBeSqlite('("val" | 0)')
@@ -31,7 +37,9 @@ it('can bitwise OR an expression and a column')
 
 it('can bitwise OR a column and an expression')
     ->expect(new BitOr(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 | `val`)')
     ->toBePgsql('(0 | "val")')
     ->toBeSqlite('(0 | "val")')

--- a/tests/Operator/Bitwise/BitXorTest.php
+++ b/tests/Operator/Bitwise/BitXorTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Bitwise\BitXor;
 
 it('can bitwise XOR two columns')
     ->expect(new BitXor('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` ^ `val2`)')
     ->toBePgsql('("val1" # "val2")')
     ->toBeSqlite('(("val1" | "val2") - ("val1" & "val2"))')
@@ -23,7 +27,9 @@ it('can bitwise XOR two expressions')
 
 it('can bitwise XOR an expression and a column')
     ->expect(new BitXor('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` ^ 0)')
     ->toBePgsql('("val" # 0)')
     ->toBeSqlite('(("val" | 0) - ("val" & 0))')
@@ -31,7 +37,9 @@ it('can bitwise XOR an expression and a column')
 
 it('can bitwise XOR a column and an expression')
     ->expect(new BitXor(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 ^ `val`)')
     ->toBePgsql('(0 # "val")')
     ->toBeSqlite('((0 | "val") - (0 & "val"))')

--- a/tests/Operator/Bitwise/ShiftLeftTest.php
+++ b/tests/Operator/Bitwise/ShiftLeftTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Bitwise\ShiftLeft;
 
 it('can bitwise shift left two columns')
     ->expect(new ShiftLeft('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('(`val1` * power(2, `val2`))')
     ->toBePgsql('("val1" << "val2")')
     ->toBeSqlite('("val1" << "val2")')
@@ -23,7 +27,9 @@ it('can bitwise shift left two expressions')
 
 it('can bitwise shift left an expression and a column')
     ->expect(new ShiftLeft('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(`val` * power(2, 0))')
     ->toBePgsql('("val" << 0)')
     ->toBeSqlite('("val" << 0)')
@@ -31,7 +37,9 @@ it('can bitwise shift left an expression and a column')
 
 it('can bitwise shift left a column and an expression')
     ->expect(new ShiftLeft(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('(0 * power(2, `val`))')
     ->toBePgsql('(0 << "val")')
     ->toBeSqlite('(0 << "val")')

--- a/tests/Operator/Bitwise/ShiftRightTest.php
+++ b/tests/Operator/Bitwise/ShiftRightTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Bitwise\ShiftRight;
 
 it('can bitwise shift right two columns')
     ->expect(new ShiftRight('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    })
     ->toBeMysql('floor(`val1` / power(2, `val2`))')
     ->toBePgsql('("val1" >> "val2")')
     ->toBeSqlite('("val1" >> "val2")')
@@ -23,7 +27,9 @@ it('can bitwise shift right two expressions')
 
 it('can bitwise shift right an expression and a column')
     ->expect(new ShiftRight('val', new Expression(0)))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('floor(`val` / power(2, 0))')
     ->toBePgsql('("val" >> 0)')
     ->toBeSqlite('("val" >> 0)')
@@ -31,7 +37,9 @@ it('can bitwise shift right an expression and a column')
 
 it('can bitwise shift right a column and an expression')
     ->expect(new ShiftRight(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'])
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
     ->toBeMysql('floor(0 / power(2, `val`))')
     ->toBePgsql('(0 >> "val")')
     ->toBeSqlite('(0 >> "val")')

--- a/tests/Operator/Comparison/BetweenTest.php
+++ b/tests/Operator/Comparison/BetweenTest.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\Between;
 
 it('can compare a column by between check with two columns')
     ->expect(new Between('val', 'min', 'max'))
-    ->toBeExecutable(['val int', 'min int', 'max int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+        $table->integer('min');
+        $table->integer('max');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` between `min` and `max`)')
@@ -17,7 +22,10 @@ it('can compare a column by between check with two columns')
 
 it('can compare a column by between check with a column and expression')
     ->expect(new Between('val', 'min', new Expression(99)))
-    ->toBeExecutable(['val int', 'min int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+        $table->integer('min');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` between `min` and 99)')
@@ -27,7 +35,10 @@ it('can compare a column by between check with a column and expression')
 
 it('can compare a column by between check with an expression and column')
     ->expect(new Between('val', new Expression(1), 'max'))
-    ->toBeExecutable(['val int', 'max int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+        $table->integer('max');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` between 1 and `max`)')
@@ -37,7 +48,10 @@ it('can compare a column by between check with an expression and column')
 
 it('can compare an expression by between check with two columns')
     ->expect(new Between(new Expression(1), 'min', 'max'))
-    ->toBeExecutable(['min int', 'max int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('min');
+        $table->integer('max');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(1 between `min` and `max`)')
@@ -47,7 +61,9 @@ it('can compare an expression by between check with two columns')
 
 it('can compare an expression by between check with an expression and column')
     ->expect(new Between(new Expression(1), new Expression(0), 'max'))
-    ->toBeExecutable(['max int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('max');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(1 between 0 and `max`)')
@@ -57,7 +73,9 @@ it('can compare an expression by between check with an expression and column')
 
 it('can compare an expression by between check with a column and expression')
     ->expect(new Between(new Expression(1), 'min', new Expression(99)))
-    ->toBeExecutable(['min int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('min');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(1 between `min` and 99)')

--- a/tests/Operator/Comparison/DistinctFromTest.php
+++ b/tests/Operator/Comparison/DistinctFromTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\DistinctFrom;
 
 it('can compare two columns by distinct check')
     ->expect(new DistinctFrom('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(not `val1` <=> `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by distinct check')
 
 it('can compare an expression and a column by distinct check')
     ->expect(new DistinctFrom('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(not `val` <=> 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by distinct check')
 
 it('can compare a column and an expression by distinct check')
     ->expect(new DistinctFrom(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(not 0 <=> `val`)')

--- a/tests/Operator/Comparison/EqualTest.php
+++ b/tests/Operator/Comparison/EqualTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\Equal;
 
 it('can compare two columns by equality check')
     ->expect(new Equal('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val1` = `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by equality check')
 
 it('can compare an expression and a column by equality check')
     ->expect(new Equal('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` = 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by equality check')
 
 it('can compare a column and an expression by equality check')
     ->expect(new Equal(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(0 = `val`)')

--- a/tests/Operator/Comparison/GreaterThanOrEqualTest.php
+++ b/tests/Operator/Comparison/GreaterThanOrEqualTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\GreaterThanOrEqual;
 
 it('can compare two columns by greater than or equal check')
     ->expect(new GreaterThanOrEqual('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val1` >= `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by greater than or equal check')
 
 it('can compare an expression and a column by greater than or equal check')
     ->expect(new GreaterThanOrEqual('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` >= 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by greater than or equal check')
 
 it('can compare a column and an expression by greater than or equal check')
     ->expect(new GreaterThanOrEqual(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(0 >= `val`)')

--- a/tests/Operator/Comparison/GreaterThanTest.php
+++ b/tests/Operator/Comparison/GreaterThanTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\GreaterThan;
 
 it('can compare two columns by greater than check')
     ->expect(new GreaterThan('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val1` > `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by greater than check')
 
 it('can compare an expression and a column by greater than check')
     ->expect(new GreaterThan('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` > 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by greater than check')
 
 it('can compare a column and an expression by greater than check')
     ->expect(new GreaterThan(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(0 > `val`)')

--- a/tests/Operator/Comparison/LessThanOrEqualTest.php
+++ b/tests/Operator/Comparison/LessThanOrEqualTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\LessThanOrEqual;
 
 it('can compare two columns by less than or equal check')
     ->expect(new LessThanOrEqual('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val1` <= `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by less than or equal check')
 
 it('can compare an expression and a column by less than or equal check')
     ->expect(new LessThanOrEqual('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` <= 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by less than or equal check')
 
 it('can compare a column and an expression by less than or equal check')
     ->expect(new LessThanOrEqual(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(0 <= `val`)')

--- a/tests/Operator/Comparison/LessThanTest.php
+++ b/tests/Operator/Comparison/LessThanTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\LessThan;
 
 it('can compare two columns by less than check')
     ->expect(new LessThan('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val1` < `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by less than check')
 
 it('can compare an expression and a column by less than check')
     ->expect(new LessThan('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` < 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by less than check')
 
 it('can compare a column and an expression by less than check')
     ->expect(new LessThan(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(0 < `val`)')

--- a/tests/Operator/Comparison/NotDistinctFromTest.php
+++ b/tests/Operator/Comparison/NotDistinctFromTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\NotDistinctFrom;
 
 it('can compare two columns by not distinct check')
     ->expect(new NotDistinctFrom('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val1');
+        $table->integer('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val1` <=> `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by not distinct check')
 
 it('can compare an expression and a column by not distinct check')
     ->expect(new NotDistinctFrom('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` <=> 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by not distinct check')
 
 it('can compare a column and an expression by not distinct check')
     ->expect(new NotDistinctFrom(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(0 <=> `val`)')

--- a/tests/Operator/Comparison/NotEqualTest.php
+++ b/tests/Operator/Comparison/NotEqualTest.php
@@ -3,11 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
 use Tpetry\QueryExpressions\Operator\Comparison\NotEqual;
 
 it('can compare two columns by not equality check')
     ->expect(new NotEqual('val1', 'val2'))
-    ->toBeExecutable(['val1 int', 'val2 int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->string('val1');
+        $table->string('val2');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val1` != `val2`)')
@@ -27,7 +31,9 @@ it('can compare two expressions by not equality check')
 
 it('can compare an expression and a column by not equality check')
     ->expect(new NotEqual('val', new Expression(0)))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(`val` != 0)')
@@ -37,7 +43,9 @@ it('can compare an expression and a column by not equality check')
 
 it('can compare a column and an expression by not equality check')
     ->expect(new NotEqual(new Expression(0), 'val'))
-    ->toBeExecutable(['val int'], options: [
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    }, options: [
         'sqlsrv' => ['position' => 'where'],
     ])
     ->toBeMysql('(0 != `val`)')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Pest\Expectation;
@@ -13,21 +12,14 @@ uses(
     TestCase::class,
 )->in(__DIR__);
 
-expect()->extend('toBeExecutable', function (
-    Closure $callback = null,
-    array $options = [],
-): Expectation {
+expect()->extend('toBeExecutable', function (Closure $migration = null, array $options = []): Expectation {
     /** @var \Illuminate\Database\Connection $connection */
     $connection = DB::connection();
 
     $table = null;
-
-    if (filled($callback)) {
+    if (filled($migration)) {
         $table = 'example_'.mt_rand();
-
-        Schema::create($table, function (Blueprint $table) use ($callback) {
-            $callback($table);
-        });
+        Schema::create($table, $migration(...));
     }
 
     $position = $options[$connection->getDriverName()]['position'] ?? 'select';

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Pest\Expectation;
 use PHPUnit\Framework\Assert;
 use Tpetry\QueryExpressions\Tests\TestCase;
@@ -11,15 +13,21 @@ uses(
     TestCase::class,
 )->in(__DIR__);
 
-expect()->extend('toBeExecutable', function (array $columns = [], array $options = []): Expectation {
+expect()->extend('toBeExecutable', function (
+    Closure $callback = null,
+    array $options = [],
+): Expectation {
     /** @var \Illuminate\Database\Connection $connection */
     $connection = DB::connection();
 
     $table = null;
-    if (filled($columns)) {
+
+    if (filled($callback)) {
         $table = 'example_'.mt_rand();
-        $columns = implode(',', $columns);
-        $connection->unprepared("CREATE TABLE {$table} ({$columns})");
+
+        Schema::create($table, function (Blueprint $table) use ($callback) {
+            $callback($table);
+        });
     }
 
     $position = $options[$connection->getDriverName()]['position'] ?? 'select';


### PR DESCRIPTION
This PR will change the columns setup in tests to use the schema builder instead of the raw db-agnostic SQL.

The need for this change came from an attempt to add a "datetime" column, where PostgreSQL will throw an error `type "datetime" does not exist`. Action run example: https://github.com/mohannadnaj-forks/laravel-query-expressions/actions/runs/6211881746/job/16861481277#step:8:274

Pros of this change: Expressive and a guaranteed db-agnostic setup. Cons of this change: More boilerplate for tests.

> Edit: The special snowflake SQLite again doesn't have this type. Maybe I should add the testing then to use the blueprint for all tests. I'll have to think about it.
> https://github.com/tpetry/laravel-query-expressions/pull/18#issuecomment-1778981253

Looks like it's PostgreSQL not SQLite?

This change is not really necessary since we can just use an additional parameter for unsupported types, like what's currently applied in the pending date format PR #18 

P.S: I wasn't familiar with the expression "special snowflake", and I laughed a lot when I read "The conviction that one (or often, one's child) is, in some way, special and should therefore be treated differently than others" lol 😹