### PR TITLE
Add “Abs” function

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,15 @@ BlogArticle::select([
 ->get();
 ```
 
+#### Math
+```php
+use Tpetry\QueryExpressions\Function\Math\{
+    Abs,
+};
+
+new Abs(string|Expression $expression);
+```
+
 #### String
 ```php
 use Tpetry\QueryExpressions\Function\String\{

--- a/src/Function/Math/Abs.php
+++ b/src/Function/Math/Abs.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\QueryExpressions\Function\Math;
+
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Grammar;
+use Tpetry\QueryExpressions\Concerns\IdentifiesDriver;
+use Tpetry\QueryExpressions\Concerns\StringizeExpression;
+
+class Abs implements Expression
+{
+    use StringizeExpression;
+    use IdentifiesDriver;
+
+    public function __construct(
+        private readonly string|Expression $expression
+    ) {
+    }
+
+    public function getValue(Grammar $grammar): string
+    {
+        $expression = $this->stringize($grammar, $this->expression);
+
+        return match ($this->identify($grammar)) {
+            'mysql', 'sqlite' => "(abs({$expression}))",
+            'pgsql', 'sqlsrv' => "abs({$expression})",
+        };
+    }
+}

--- a/src/Function/Math/Abs.php
+++ b/src/Function/Math/Abs.php
@@ -11,11 +11,11 @@ use Tpetry\QueryExpressions\Concerns\StringizeExpression;
 
 class Abs implements Expression
 {
-    use StringizeExpression;
     use IdentifiesDriver;
+    use StringizeExpression;
 
     public function __construct(
-        private readonly string|Expression $expression
+        private readonly string|Expression $expression,
     ) {
     }
 

--- a/tests/Function/Math/AbsTest.php
+++ b/tests/Function/Math/AbsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Tpetry\QueryExpressions\Function\Math\Abs;
+
+it('can abs a column')
+    ->expect(new Abs('val'))
+    ->toBeExecutable(function (Blueprint $table) {
+        $table->integer('val');
+    })
+    ->toBeMysql('(abs(`val`))')
+    ->toBePgsql('abs("val")')
+    ->toBeSqlite('(abs("val"))')
+    ->toBeSqlsrv('abs([val])');
+
+it('can abs an expression')
+    ->expect(new Abs(new Expression('sum(1)')))
+    ->toBeExecutable()
+    ->toBeMysql('(abs(sum(1)))')
+    ->toBePgsql('abs(sum(1))')
+    ->toBeSqlite('(abs(sum(1)))')
+    ->toBeSqlsrv('abs(sum(1))');


### PR DESCRIPTION
Hey @tpetry 

This adds the mathematical function absolute e.g the "abs" function. As a valid sql expression.

I believe it's a common enough sql function to actually add it in.

---
I was not entirely sure where to put it so i figured it is a mathematical sql function so i added it in a new namespace under `Function` called `Math`. 