### PR TITLE
chore: update composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,16 @@
         "illuminate/support": "^10.0"
     },
     "require-dev": {
+        "larastan/larastan": "^2.7.0",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0",
-        "nunomaduro/larastan": "^2.0.1",
+        "nunomaduro/collision": "^7.0.0",
         "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^1.21",
-        "pestphp/pest-plugin-laravel": "^1.1",
+        "pestphp/pest": "^2.28.1",
+        "pestphp/pest-plugin-laravel": "^2.2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.5.3",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,7 +12,7 @@ uses(
     TestCase::class,
 )->in(__DIR__);
 
-expect()->extend('toBeExecutable', function (Closure $migration = null, array $options = []): Expectation {
+expect()->extend('toBeExecutable', function (?Closure $migration = null, array $options = []): Expectation {
     /** @var \Illuminate\Database\Connection $connection */
     $connection = DB::connection();
 


### PR DESCRIPTION
Currently, the `"post-autoload-dump": "@php ./vendor/bin/testbench package:discover"` script in PHP 8.3.1 is failing due to:
https://github.com/mohannadnaj-forks/laravel-query-expressions/actions/runs/7284668115/job/19850377090?pr=7#step:4:479

```
> @php ./vendor/bin/testbench package:discover --ansi
PHP Fatal error:  Orchestra\Testbench\Foundation\Console\TestCommand::getConfigurationFile() has #[\Override] attribute, but no matching parent method exists in /home/runner/work/laravel-query-expressions/laravel-query-expressions/vendor/orchestra/testbench-core/src/Foundation/Console/TestCommand.php on line 165

   Symfony\Component\ErrorHandler\Error\FatalError 

  Orchestra\Testbench\Foundation\Console\TestCommand::getConfigurationFile() has #[\Override] attribute, but no matching parent method exists

  at vendor/orchestra/testbench-core/src/Foundation/Console/TestCommand.php:165
    161▕      *
    162▕      * @return string
    163▕      */
    164▕     #[\Override]
  ➜ 165▕     protected function getConfigurationFile()
    166▕     {
    167▕         return $this->phpUnitConfigurationFile();
    168▕     }
    169▕ }
```

Probably it wasn't reflected in the CI because the relevent testbench release was 5 days ago https://github.com/orchestral/testbench/releases/tag/v8.18.0
