### PR TITLE
implements conditionExpression instead of expression

### DIFF
--- a/src/Language/CaseGroup.php
+++ b/src/Language/CaseGroup.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tpetry\QueryExpressions\Language;
 
-use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\ConditionExpression;
 use Illuminate\Database\Grammar;
 use Tpetry\QueryExpressions\Concerns\IdentifiesDriver;
 use Tpetry\QueryExpressions\Concerns\StringizeExpression;
 
-class CaseGroup implements Expression
+class CaseGroup implements ConditionExpression
 {
     use IdentifiesDriver;
     use StringizeExpression;


### PR DESCRIPTION
In order to use the CaseGroup expression as "top-level" expression we must implement condition expression instead of expression.

Before:

```php
where(new CaseGroup)
```
Generates an `is null` constraint at the end.

after this pr
```php
where(new CaseGroup)
```
Does **NOT** generate an `is null` constraint at the end.
